### PR TITLE
add limit config

### DIFF
--- a/.github/workflows/erlang-pr.yml
+++ b/.github/workflows/erlang-pr.yml
@@ -7,28 +7,11 @@ on:
 
 jobs:
   build:
-    name: Build and verify
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: valitydev/action-setup-thrift@v1
-
-      - uses: erlef/setup-beam@v1
-        id: beam
-        with:
-          otp-version: "24"
-          rebar3-version: "3.18"
-
-      - name: Restore PLT cache
-        uses: actions/cache@v2
-        id: plt-cache
-        with:
-          key: |
-            ${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-plt
-          path: |
-            _build/default/rebar3_*_plt
-
-      - run: rebar3 compile
-      - run: rebar3 xref
-      - run: rebar3 dialyzer
+    uses: valitydev/erlang-workflows/.github/workflows/erlang-simple-build.yml@v1
+    with:
+      otp-version: 24
+      rebar-version: 3.18
+      use-thrift: true
+      thrift-version: 0.14.2.3
+      run-eunit: false
+      run-common-test: false

--- a/.github/workflows/frontend-pr.yml
+++ b/.github/workflows/frontend-pr.yml
@@ -6,16 +6,16 @@ on:
 
 jobs:
   configured:
-    uses: valitydev/action-frontend/.github/workflows/configured.yml@v0.1
+    uses: valitydev/action-frontend/.github/workflows/configured.yml@v1.0
   check:
     name: Check
     runs-on: ubuntu-latest
     needs: configured
     if: needs.configured.outputs.exists == 'true'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: valitydev/action-frontend/setup@v1
-      - uses: valitydev/action-setup-thrift@v1.0.0
+      - uses: valitydev/action-setup-thrift@v1.0.2
       - run: npm i  # protocols don't always update the package-lock.json, so installing from package.json
       - name: Codegen
         run: npm run codegen

--- a/.github/workflows/frontend-publish.yml
+++ b/.github/workflows/frontend-publish.yml
@@ -6,16 +6,16 @@ on:
 
 jobs:
   configured:
-    uses: valitydev/action-frontend/.github/workflows/configured.yml@v0.1
+    uses: valitydev/action-frontend/.github/workflows/configured.yml@v1.0
   publish:
     name: Publish
     runs-on: ubuntu-latest
     needs: configured
     if: needs.configured.outputs.exists == 'true'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: valitydev/action-frontend/setup@v1
-      - uses: valitydev/action-setup-thrift@v1.0.0
+      - uses: valitydev/action-setup-thrift@v1.0.2
       - run: npm i # protocols don't always update the package-lock.json, so installing from package.json
       - name: Build
         run: npm run codegen

--- a/.github/workflows/java-deploy.yml
+++ b/.github/workflows/java-deploy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    uses: valitydev/java-workflow/.github/workflows/maven-thrift-deploy.yml@v1
+    uses: valitydev/java-workflow/.github/workflows/maven-thrift-deploy.yml@v3
     secrets:
       server-username: ${{ secrets.OSSRH_USERNAME }}
       server-password: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   build:
-    uses: valitydev/java-workflow/.github/workflows/maven-thrift-build.yml@v1
+    uses: valitydev/java-workflow/.github/workflows/maven-thrift-build.yml@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@vality/domain-proto": "2.0.1-24932cd.0",
         "@vality/thrift-codegen": "2.3.2"
       }
     },
@@ -116,6 +117,13 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
       "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
       "dev": true
+    },
+    "node_modules/@vality/domain-proto": {
+      "version": "2.0.1-24932cd.0",
+      "resolved": "https://registry.npmjs.org/@vality/domain-proto/-/domain-proto-2.0.1-24932cd.0.tgz",
+      "integrity": "sha512-ABpiYRG6x0/G7qSI50BS0aCz+FBJpbvLYbZrzWUXLfB+UYCJDduhCW4ZmFk38cMJTG1l/bgw2+3fb1n6bE5gbQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@vality/thrift-codegen": {
       "version": "2.3.2",
@@ -2973,6 +2981,12 @@
       "version": "18.11.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
       "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
+      "dev": true
+    },
+    "@vality/domain-proto": {
+      "version": "2.0.1-24932cd.0",
+      "resolved": "https://registry.npmjs.org/@vality/domain-proto/-/domain-proto-2.0.1-24932cd.0.tgz",
+      "integrity": "sha512-ABpiYRG6x0/G7qSI50BS0aCz+FBJpbvLYbZrzWUXLfB+UYCJDduhCW4ZmFk38cMJTG1l/bgw2+3fb1n6bE5gbQ==",
       "dev": true
     },
     "@vality/thrift-codegen": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@vality/dominant-cache-proto",
   "version": "2.0.0",
   "scripts": {
-    "codegen": "thrift-codegen --i ./proto --n dominant_cache"
+    "codegen": "thrift-codegen --i ./proto --i ./node_modules/damsel/proto --n dominant_cache"
   },
   "publishConfig": {
     "access": "public",
@@ -33,6 +33,7 @@
     }
   },
   "devDependencies": {
-    "@vality/thrift-codegen": "2.3.2"
+    "@vality/thrift-codegen": "2.3.2",
+    "@vality/domain-proto": "2.0.1-24932cd.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@vality/dominant-cache-proto",
   "version": "2.0.0",
   "scripts": {
-    "codegen": "thrift-codegen --i ./proto --i ./node_modules/damsel --n dominant_cache"
+    "codegen": "thrift-codegen --i ./proto --i ./node_modules/@vality/domain-proto --n dominant_cache"
   },
   "publishConfig": {
     "access": "public",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@vality/dominant-cache-proto",
   "version": "2.0.0",
   "scripts": {
-    "codegen": "thrift-codegen --i ./proto --i ./node_modules/damsel/proto --n dominant_cache"
+    "codegen": "thrift-codegen --i ./proto --i ./node_modules/damsel --n dominant_cache"
   },
   "publishConfig": {
     "access": "public",

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>dev.vality</groupId>
             <artifactId>damsel</artifactId>
-            <version>1.538-5addc41</version>
+            <version>1.648-ad715bd</version>
         </dependency>
         <dependency>
             <groupId>javax.annotation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.vality</groupId>
         <artifactId>library-parent-pom</artifactId>
-        <version>1.0.0</version>
+        <version>2.0.3</version>
     </parent>
 
     <artifactId>dominant-cache-proto</artifactId>
@@ -46,6 +46,16 @@
 
     <build>
         <finalName>${project.artifactId}</finalName>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/proto</directory>
+                <targetPath>${project.build.outputDirectory}/proto</targetPath>
+                <includes>
+                    <include>*.thrift</include>
+                </includes>
+                <filtering>false</filtering>
+            </resource>
+        </resources>
         <plugins>
             <!-- THRIFT -->
             <plugin>
@@ -70,7 +80,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/proto/dominant_cache.thrift
+++ b/proto/dominant_cache.thrift
@@ -1,6 +1,9 @@
 namespace java dev.vality.damsel.dominant.cache
 namespace erlang dominant_cache
 
+include "proto/base.thrift"
+include "proto/limiter_config.thrift"
+
 typedef string CategoryRef
 typedef string CategoryName
 typedef string CategoryDescription
@@ -37,6 +40,8 @@ typedef string CountryRef
 typedef string ProviderRef
 
 typedef string TerminalRef
+
+typedef string LimitConfigRef
 
 enum CashRegisterProviderParameterType {
     string_type
@@ -111,6 +116,11 @@ struct Terminal {
     4: optional string description
 }
 
+struct LimitConfigObject {
+    1: required LimitConfigRef ref
+    2: required limiter_config.LimitConfig data
+}
+
 service DominantCache {
 
         list<Category> GetCategories ()
@@ -128,5 +138,7 @@ service DominantCache {
         list<Provider> GetProviders ()
 
         list<Terminal> GetTerminals ()
+
+        list<LimitConfigObject> GetLimits ()
 
 }

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,65 @@
+%% Common project erlang options.
+{erl_opts, [
+    % mandatory
+    debug_info,
+    warnings_as_errors,
+    warn_export_all,
+    warn_missing_spec,
+    warn_untyped_record,
+    warn_export_vars,
+
+    % by default
+    warn_unused_record,
+    warn_bif_clash,
+    warn_obsolete_guard,
+    warn_unused_vars,
+    warn_shadow_vars,
+    warn_unused_import,
+    warn_unused_function,
+    warn_deprecated_function,
+
+    % at will
+    % bin_opt_info
+    % no_auto_import,
+    warn_missing_spec_all
+]}.
+
+{deps, [
+    {damsel, {git, "https://github.com/valitydev/damsel.git", {branch, "master"}}}
+]}.
+
+%% XRef checks
+{xref_checks, [
+    undefined_function_calls,
+    undefined_functions,
+    deprecated_functions_calls,
+    deprecated_functions
+]}.
+
+%% Dialyzer static analyzing
+{dialyzer, [
+    {warnings, [
+        % mandatory
+        unmatched_returns,
+        error_handling,
+        unknown
+    ]},
+    {plt_apps, all_deps}
+]}.
+
+{plugins, [
+    {rebar3_thrift_compiler,
+        {git, "https://github.com/valitydev/rebar3_thrift_compiler.git", {tag, "0.4"}}}
+]}.
+
+{provider_hooks, [
+    {pre, [
+        {compile, {thrift, compile}},
+        {clean, {thrift, clean}}
+    ]}
+]}.
+
+{thrift_compiler_opts, [
+    {in_dir, "proto"},
+    {gen, "erlang:app_namespaces"}
+]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,4 @@
+[{<<"damsel">>,
+  {git,"https://github.com/valitydev/damsel.git",
+       {ref,"c32f50f875bd1c58957e507420a23f7d2fac3ecb"}},
+  0}].


### PR DESCRIPTION
Для сервиса, генерации реестров по трансграничным переводам, нужно знать информацию о том относится ли ошибка с отправителю или получателю перевода (withdrawal). Этого нельзя точно узнать из событий по Withdrawal, но мы можем определить посмотрев на reason ошибки в событии изменения статуса, в таком духе:
```json
{
  "code": "no_route_found",
  "reason": "{rejected_routes,[{{domain_ProviderRef,346},{domain_TerminalRef,437},{terms_violation,{overflow,[{<<\"withdrawal_day_amount_limit_rub\">>,942070500,940000000}]}}},{{domain_ProviderRef,339},{domain_TerminalRef,271},{terms_violation,terminal_forbidden}}]}"
}
```
Тут мы видим, что сработал лимит, но не можем сказать относится ли он к отправителю или получателю. Поэтому, есть вариант, взять id лимита `withdrawal_day_amount_limit_rub`, сходить с ним в `dominant-cache` и узнать относится ли эта ошибка к отправителю или получателю. Таким образом, мы сможем сформировать, в реестрах неуспешных платежей, код ошибки типа `sender_limit_exceeded` или `receiver_limit_exceeded`.